### PR TITLE
add a 'commit' command for popping the stack without emoji or other output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ As you complete tasks, pop them off the stack to see the next one.
 $ stacker pop
 ```
 
+If you are using Stacker to pre-write commit messages, you can use the current task as a git commit message 
+using the `commit` command (this will also pop the task).
+
+```shell
+$ git commit -m (stacker commit)
+```
+
 You can always be reminded of what you're currently working on.
 
 

--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -19,6 +19,24 @@ program.command("init").action(reset);
 
 program.command("clear").action(reset);
 
+program.command("commit").action(async () => {
+  const [head, ...rest] = await storage();
+
+  if (!head) {
+    console.error("❌ Nothing on the stack")
+    process.exitCode = 1;
+    return
+  }
+
+  try {
+    await writeFile(filePath(), JSON.stringify(rest));
+    console.log(`${head}`);
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 2;
+  }
+});
+
 program.command("peek").action(async () => {
   try {
     const [head, ...rest] = await storage();


### PR DESCRIPTION
Disclaimer: I've never written javascript or node, so this may be horrible code but it worked.  

I found Stacker useful in preparing git commit messages ahead of time - as I started on a task - like you alluded to in https://tanzu.vmware.com/developer/blog/how-and-why-to-write-commit-messages-first/

By adding the `commit` command, I could pipe the output directly to the `git commit` command without also getting the output from `pop` (like the next task or the All Done rainbow message)

I also considered writing the popped task to a file that could be used in `git commit -eF message.txt`, like:

```
$ stacker pop message.txt
Task popped to message.txt, commit using `git commit -eF message.txt`
```

Or even support multiple tasks like:
```
$ stacker pop 3 message.txt
Tasks popped to message.txt, commit using `git commit -eF message.txt`
```
As well as an option to not use emoji such as:
```
$ stacker pop --bare
```
